### PR TITLE
fixed push notifications for Edge

### DIFF
--- a/PushSharp.Tests/Settings.cs
+++ b/PushSharp.Tests/Settings.cs
@@ -96,6 +96,10 @@ namespace PushSharp.Tests
 
             [JsonProperty("firefox_outdated_subscription")]
             public WebPushSubscription FirefoxOutdatedSubscription { get; set; }
+
+
+            [JsonProperty("edge_subscription")]
+            public WebPushSubscription EdgeSubscription { get; set; }
         }
     }
 }

--- a/PushSharp.Tests/WebPushRealTests.cs
+++ b/PushSharp.Tests/WebPushRealTests.cs
@@ -124,6 +124,25 @@ namespace PushSharp.Tests
             ctx.AssertSubscriptionExpired();
         }
 
+        [Test]
+        public void Edge_Notification_With_Payload_Test()
+        {
+            var settings = Settings.Instance;
+            var ctx = new BrokerContext();
+            ctx.Start();
+
+            var subsription = settings.WebPush.EdgeSubscription;
+
+            var notif = new WebPushNotification(subsription);
+            notif.Payload = JObject.Parse("{ \"somekey\" : \"somevalue\" }");
+            ctx.Broker.QueueNotification(notif);
+
+            ctx.Broker.Stop();
+
+            Assert.AreEqual(1, ctx.Succeeded);
+            Assert.AreEqual(0, ctx.Failed);
+        }
+
         private class BrokerContext
         {
             public int Failed { get; private set; }

--- a/PushSharp.Web/WebPushConnection.cs
+++ b/PushSharp.Web/WebPushConnection.cs
@@ -57,8 +57,8 @@ namespace PushSharp.Web
                 request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
                 request.Content.Headers.ContentLength = encryptedPayload.Payload.Length;
                 request.Content.Headers.ContentEncoding.Add("aesgcm");
-                request.Headers.Add("Crypto-Key", "keyid=p256dh;dh=" + encryptedPayload.Base64EncodePublicKey());
-                request.Headers.Add("Encryption", "keyid=p256dh;salt=" + encryptedPayload.Base64EncodeSalt());
+                request.Headers.Add("Crypto-Key", "dh=" + encryptedPayload.Base64EncodePublicKey());
+                request.Headers.Add("Encryption", "salt=" + encryptedPayload.Base64EncodeSalt());
             }
 
             request.Headers.TryAddWithoutValidation("TTL", DefaultTTL);


### PR DESCRIPTION
Windows Push Notification Service notification server, который используется в Edge, ругается, если отправлять в хедерах _Crypto-Key_ и _Encryption_ более одного значения.
В [спецификации](https://tools.ietf.org/html/draft-ietf-webpush-encryption-04) указано, что параметр _keyid_ необязателен в указанных хедерах.

> An Application Server MUST include exactly one entry in the
>    Encryption field, and at most one entry having a "dh" parameter in
>    the Crypto-Key field.  This allows the "keyid" parameter to be
>    omitted from both header fields.

Поэтому просто удалил эту часть хедеров, тем самым починив пуш нотификации в Edge браузере.