### PR TITLE
Implement the new Apple Push Notification Service (APNs) API to replace the deprecated protocol.

### DIFF
--- a/PushSharp.Amazon/PushSharp.Amazon.csproj
+++ b/PushSharp.Amazon/PushSharp.Amazon.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>PushSharp.Amazon</RootNamespace>
     <AssemblyName>PushSharp.Amazon</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\PushSharp-Signing.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/PushSharp.Amazon/PushSharp.Amazon.csproj
+++ b/PushSharp.Amazon/PushSharp.Amazon.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>PushSharp.Amazon</RootNamespace>
     <AssemblyName>PushSharp.Amazon</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\PushSharp-Signing.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/PushSharp.Apple/ApnsHttp2Connection.cs
+++ b/PushSharp.Apple/ApnsHttp2Connection.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 using System.Net;
+using System.Net.Http;
 
 namespace PushSharp.Apple
 {
@@ -45,13 +46,17 @@ namespace PushSharp.Apple
             if (certificate != null)
                 certificates.Add (certificate);
 
-            var http2Settings = new HttpTwo.Http2ConnectionSettings (
-                Configuration.Host,
-               (uint)Configuration.Port, 
-                true, 
-                certificates);
+            var handler = new WinHttpHandler();
+            handler.ServerCertificateValidationCallback = (sender, cert, chain, sslPolicyErrors) => true;
+            handler.SslProtocols = System.Security.Authentication.SslProtocols.Tls12;
             
-            http2 = new HttpTwo.Http2Client (http2Settings);
+            foreach (X509Certificate cert in certificates)
+            {
+                if (cert is X509Certificate2 cert2)
+                    handler.ClientCertificates.Add(cert2);
+            }
+
+            httpClient = new HttpClient(handler);
         }
 
         public ApnsHttp2Configuration Configuration { get; private set; }
@@ -59,54 +64,67 @@ namespace PushSharp.Apple
         X509CertificateCollection certificates;
         X509Certificate2 certificate;
         int id = 0;
-        HttpTwo.Http2Client http2;
+        HttpClient httpClient;
 
         public async Task Send (ApnsHttp2Notification notification)
         {
             var url = string.Format ("https://{0}:{1}/3/device/{2}", 
                           Configuration.Host,
                           Configuration.Port,
-                          notification.DeviceToken);            
-            var uri = new Uri (url);
+                          notification.DeviceToken);
 
             var payload = notification.Payload.ToString ();
 
-            var data = Encoding.ASCII.GetBytes (payload);
+            var request = new HttpRequestMessage(HttpMethod.Post, url);
+            request.Version = new Version(2, 0);
+            request.Content = new StringContent(payload, Encoding.UTF8, "application/json");
 
-            var headers = new NameValueCollection ();
-            headers.Add ("apns-id", notification.Uuid); // UUID
+            request.Headers.Add("apns-id", notification.Uuid);
+
+            if((string.IsNullOrEmpty(notification.PushType)))
+            {
+                notification.PushType = "background";
+            }
+            request.Headers.Add("apns-push-type", notification.PushType);
 
             if (notification.Expiration.HasValue) {
                 var sinceEpoch = notification.Expiration.Value.ToUniversalTime () - new DateTime (1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
                 var secondsSinceEpoch = (long)sinceEpoch.TotalSeconds;
-                headers.Add ("apns-expiration", secondsSinceEpoch.ToString ()); //Epoch in seconds
+                request.Headers.Add ("apns-expiration", secondsSinceEpoch.ToString ());
             }
 
             if (notification.Priority.HasValue)
-                headers.Add ("apns-priority", notification.Priority == ApnsPriority.Low ? "5" : "10"); // 5 or 10
-
-            headers.Add ("content-length", data.Length.ToString ());
+                request.Headers.Add ("apns-priority", notification.Priority == ApnsPriority.Low ? "5" : "10");
 
             if (!string.IsNullOrEmpty (notification.Topic)) 
-                headers.Add ("apns-topic", notification.Topic); // string topic
+                request.Headers.Add ("apns-topic", notification.Topic);
 
-            var response = await http2.Post (uri, headers, data);
-            
-            if (response.Status == HttpStatusCode.OK) {
-                // Check for matching uuid's
-                var responseUuid = response.Headers ["apns-id"];
-                if (responseUuid != notification.Uuid)
-                    throw new Exception ("Mismatched APNS-ID header values");
+            HttpResponseMessage response;
+            try
+            {
+                response = await httpClient.SendAsync(request).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                throw;
+            }
+
+            if (response.StatusCode == HttpStatusCode.OK) {
+                if (response.Headers.Contains("apns-id"))
+                {
+                    var responseUuid = response.Headers.GetValues("apns-id").FirstOrDefault();
+                    if (responseUuid != notification.Uuid)
+                        throw new Exception ("Mismatched APNS-ID header values");
+                }
             } else {
-                // Try parsing json body
                 var json = new JObject ();
 
-                if (response.Body != null && response.Body.Length > 0) {
-                    var body = Encoding.ASCII.GetString (response.Body);
-                    json = JObject.Parse (body);
+                var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (!string.IsNullOrEmpty(responseBody)) {
+                    json = JObject.Parse (responseBody);
                 }
 
-                if (response.Status == HttpStatusCode.Gone) {
+                if (response.StatusCode == HttpStatusCode.Gone) {
 
                     var timestamp = DateTime.UtcNow;
                     if (json != null && json["timestamp"] != null) {
@@ -114,20 +132,16 @@ namespace PushSharp.Apple
                         timestamp = new DateTime (1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc).AddSeconds (sinceEpoch);
                     }
 
-                    // Expired
-                    throw new PushSharp.Core.DeviceSubscriptonExpiredException {
+                    throw new PushSharp.Core.DeviceSubscriptionExpiredException (notification) {
                         OldSubscriptionId = notification.DeviceToken,
                         NewSubscriptionId = null,
                         ExpiredAt = timestamp
                     };
                 }
 
-                // Get the reason
                 var reasonStr = json.Value<string> ("reason");
 
-                var reason = (ApnsHttp2FailureReason)Enum.Parse (typeof (ApnsHttp2FailureReason), reasonStr, true);
-
-                throw new ApnsHttp2NotificationException (reason, notification);
+                throw new Exception("Http2: " + reasonStr);
             }
         }
     }

--- a/PushSharp.Apple/ApnsHttp2Connection.cs
+++ b/PushSharp.Apple/ApnsHttp2Connection.cs
@@ -99,15 +99,7 @@ namespace PushSharp.Apple
             if (!string.IsNullOrEmpty (notification.Topic)) 
                 request.Headers.Add ("apns-topic", notification.Topic);
 
-            HttpResponseMessage response;
-            try
-            {
-                response = await httpClient.SendAsync(request).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                throw;
-            }
+            HttpResponseMessage response = await httpClient.SendAsync(request).ConfigureAwait(false);
 
             if (response.StatusCode == HttpStatusCode.OK) {
                 if (response.Headers.Contains("apns-id"))
@@ -123,8 +115,10 @@ namespace PushSharp.Apple
                 if (!string.IsNullOrEmpty(responseBody)) {
                     json = JObject.Parse (responseBody);
                 }
+                
+                var reason = json.Value<string> ("reason");
 
-                if (response.StatusCode == HttpStatusCode.Gone) {
+                if (response.StatusCode == HttpStatusCode.Gone || reason == "BadDeviceToken") {
 
                     var timestamp = DateTime.UtcNow;
                     if (json != null && json["timestamp"] != null) {
@@ -139,9 +133,7 @@ namespace PushSharp.Apple
                     };
                 }
 
-                var reasonStr = json.Value<string> ("reason");
-
-                throw new Exception("Http2: " + reasonStr);
+                throw new Exception("Http2: " + reason);
             }
         }
     }

--- a/PushSharp.Apple/ApnsHttp2Notification.cs
+++ b/PushSharp.Apple/ApnsHttp2Notification.cs
@@ -22,6 +22,12 @@ namespace PushSharp.Apple
         public string Uuid { get; set; }
 
         /// <summary>
+        /// apns-push-type
+        /// </summary>
+        /// <value>background or alert</value>
+        public string PushType { get; set; }
+
+        /// <summary>
         /// Device Token to send notifications to
         /// </summary>
         /// <value>The device token.</value>

--- a/PushSharp.Apple/PushSharp.Apple.csproj
+++ b/PushSharp.Apple/PushSharp.Apple.csproj
@@ -7,8 +7,8 @@
     <OutputType>Library</OutputType>
     <RootNamespace>PushSharp.Apple</RootNamespace>
     <AssemblyName>PushSharp.Apple</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <SignAssembly>true</SignAssembly>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>..\PushSharp-Signing.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -34,9 +34,29 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.WinHttpHandler, Version=4.0.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Http.WinHttpHandler.4.7.2\lib\net461\System.Net.Http.WinHttpHandler.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ApnsHttp2Configuration.cs" />
+    <Compile Include="ApnsHttp2Connection.cs" />
+    <Compile Include="ApnsHttp2Notification.cs" />
+    <Compile Include="ApnsHttp2ServiceConnection.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ApnsServiceConnection.cs" />
     <Compile Include="ApnsConnection.cs" />
@@ -53,6 +73,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/PushSharp.Apple/PushSharp.Apple.csproj
+++ b/PushSharp.Apple/PushSharp.Apple.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>PushSharp.Apple</RootNamespace>
     <AssemblyName>PushSharp.Apple</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>..\PushSharp-Signing.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/PushSharp.Apple/app.config
+++ b/PushSharp.Apple/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/PushSharp.Apple/packages.config
+++ b/PushSharp.Apple/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-  <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
-  <package id="System.Memory" version="4.5.4" targetFramework="net48" />
-  <package id="System.Net.Http.WinHttpHandler" version="4.7.2" targetFramework="net48" />
-  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net48" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net472" />
+  <package id="System.Net.Http.WinHttpHandler" version="4.7.2" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net472" />
 </packages>

--- a/PushSharp.Apple/packages.config
+++ b/PushSharp.Apple/packages.config
@@ -1,4 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net48" />
+  <package id="System.Net.Http.WinHttpHandler" version="4.7.2" targetFramework="net48" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net48" />
 </packages>

--- a/PushSharp.Blackberry/PushSharp.Blackberry.csproj
+++ b/PushSharp.Blackberry/PushSharp.Blackberry.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>PushSharp.Blackberry</RootNamespace>
     <AssemblyName>PushSharp.Blackberry</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\PushSharp-Signing.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/PushSharp.Blackberry/PushSharp.Blackberry.csproj
+++ b/PushSharp.Blackberry/PushSharp.Blackberry.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>PushSharp.Blackberry</RootNamespace>
     <AssemblyName>PushSharp.Blackberry</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\PushSharp-Signing.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/PushSharp.Core/PushSharp.Core.csproj
+++ b/PushSharp.Core/PushSharp.Core.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>PushSharp.Core</RootNamespace>
     <AssemblyName>PushSharp.Core</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>..\PushSharp-Signing.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/PushSharp.Core/PushSharp.Core.csproj
+++ b/PushSharp.Core/PushSharp.Core.csproj
@@ -7,8 +7,8 @@
     <OutputType>Library</OutputType>
     <RootNamespace>PushSharp.Core</RootNamespace>
     <AssemblyName>PushSharp.Core</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <SignAssembly>true</SignAssembly>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>..\PushSharp-Signing.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/PushSharp.Firefox/PushSharp.Firefox.csproj
+++ b/PushSharp.Firefox/PushSharp.Firefox.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>PushSharp.Firefox</RootNamespace>
     <AssemblyName>PushSharp.Firefox</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\PushSharp-Signing.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/PushSharp.Firefox/PushSharp.Firefox.csproj
+++ b/PushSharp.Firefox/PushSharp.Firefox.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>PushSharp.Firefox</RootNamespace>
     <AssemblyName>PushSharp.Firefox</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\PushSharp-Signing.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/PushSharp.Google/PushSharp.Google.csproj
+++ b/PushSharp.Google/PushSharp.Google.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>PushSharp.Google</RootNamespace>
     <AssemblyName>PushSharp.Google</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\PushSharp-Signing.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/PushSharp.Google/PushSharp.Google.csproj
+++ b/PushSharp.Google/PushSharp.Google.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>PushSharp.Google</RootNamespace>
     <AssemblyName>PushSharp.Google</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\PushSharp-Signing.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/PushSharp.Tests/ApnsRealTest.cs
+++ b/PushSharp.Tests/ApnsRealTest.cs
@@ -30,14 +30,18 @@ namespace PushSharp.Tests
 
             IEnumerable<string> deviceTokens =
             [
-                "2a3c7aeeb200ed16be48f8c743dde0a1eaddea4f5c7c6eb12fbfea1dd44ac161",
-                "2a3c7aeeb200ed16be48f8c743dde0a1eaddea4f5c7c6eb12fbfea1dd44ac161"
+                "e155217897df8cde740a688643b511fd8e477094efe906e7d28b018010676af8",
+                "e155217897df8cde740a688643b511fd8e477094efe906e7d28b018010676af8",
+                "e155217897df8cde740a688643b511fd8e477094efe906e7d28b018010676af8",
+                // "e155217897df8cde740a688643b511fd8e477094efe906e7d28b018010676af8",
+                // "e155217897df8cde740a688643b511fd8e477094efe906e7d28b018010676af8",
             ];
             foreach (var dt in deviceTokens) {
                 attempted++;
                 broker.QueueNotification (new ApnsHttp2Notification {
                     DeviceToken = dt,
                     Topic = "net.logicsoftware.easyprojects",
+                    PushType = "alert",
                     Payload = JObject.Parse (
                         """
                         {

--- a/PushSharp.Tests/ApnsRealTest.cs
+++ b/PushSharp.Tests/ApnsRealTest.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
 using NUnit.Framework;
 using PushSharp.Apple;
 using Newtonsoft.Json.Linq;
@@ -16,8 +18,8 @@ namespace PushSharp.Tests
             var failed = 0;
             var attempted = 0;
 
-            var config = new ApnsConfiguration (ApnsConfiguration.ApnsServerEnvironment.Sandbox, Settings.Instance.ApnsCertificateFile, Settings.Instance.ApnsCertificatePassword);
-            var broker = new ApnsServiceBroker (config);
+            var config = new ApnsHttp2Configuration (ApnsHttp2Configuration.ApnsServerEnvironment.Production, FindByThumbprint("BB80CA965848CE009580C64317E592CDC9C29F3D"));
+            var broker = new ApnsHttp2ServiceBroker (config);
             broker.OnNotificationFailed += (notification, exception) => {
                 failed++;
             };
@@ -26,11 +28,43 @@ namespace PushSharp.Tests
             };
             broker.Start ();
 
-            foreach (var dt in Settings.Instance.ApnsDeviceTokens) {
+            IEnumerable<string> deviceTokens =
+            [
+                "2a3c7aeeb200ed16be48f8c743dde0a1eaddea4f5c7c6eb12fbfea1dd44ac161",
+                "2a3c7aeeb200ed16be48f8c743dde0a1eaddea4f5c7c6eb12fbfea1dd44ac161"
+            ];
+            foreach (var dt in deviceTokens) {
                 attempted++;
-                broker.QueueNotification (new ApnsNotification {
+                broker.QueueNotification (new ApnsHttp2Notification {
                     DeviceToken = dt,
-                    Payload = JObject.Parse ("{ \"aps\" : { \"alert\" : \"Hello PushSharp!\" } }")
+                    Topic = "net.logicsoftware.easyprojects",
+                    Payload = JObject.Parse (
+                        """
+                        {
+                          "aps": {
+                            "content-available": 1,
+                            "sound": "default",
+                            "alert": {
+                              "title": "tyrtyrt",
+                              "loc-key": "Notification.TaskMessageAdded.Body",
+                              "loc-args": [
+                                "Natalia Romashevskaya",
+                                "@Administrator rtyrtyrtyrtyrty"
+                              ]
+                            }
+                          },
+                          "data": {
+                            "Type": "TaskMessageAdded",
+                            "FeedId": 5813066,
+                            "TaskId": 3900,
+                            "TaskName": "tyrtyrt",
+                            "MessageId": 5855812,
+                            "MessageText": "@Administrator rtyrtyrtyrtyrty",
+                            "PostedByUserId": 112,
+                            "PostedByUserName": "Natalia Romashevskaya"
+                          }
+                        }
+                        """)
                 });
             }
 
@@ -54,6 +88,38 @@ namespace PushSharp.Tests
                 // timestamp is the time the token was reported as expired
             };
             fbs.Check ();
+        }
+        
+        private static X509Certificate2 FindByThumbprint(string thumbprint)
+        {
+            if (string.IsNullOrWhiteSpace(thumbprint))
+            {
+                throw new ArgumentNullException(nameof(thumbprint));
+            }
+
+            X509Store certStore = new X509Store(StoreName.My, StoreLocation.LocalMachine);
+            certStore.Open(OpenFlags.ReadOnly);
+
+            try
+            {
+                X509Certificate2Collection certCollection = certStore.Certificates.Find(
+                    X509FindType.FindByThumbprint,
+                    thumbprint,
+                    false);
+
+                if (certCollection.Count > 0)
+                {
+                    return certCollection[0];
+                }
+                else
+                {
+                    throw new InvalidOperationException("Unable to find a certificate with thumbprint " + thumbprint);
+                }
+            }
+            finally
+            {
+                certStore.Close();
+            }
         }
     }
 }

--- a/PushSharp.Tests/ApnsRealTest.cs
+++ b/PushSharp.Tests/ApnsRealTest.cs
@@ -30,11 +30,6 @@ namespace PushSharp.Tests
 
             IEnumerable<string> deviceTokens =
             [
-                "e155217897df8cde740a688643b511fd8e477094efe906e7d28b018010676af8",
-                "e155217897df8cde740a688643b511fd8e477094efe906e7d28b018010676af8",
-                "e155217897df8cde740a688643b511fd8e477094efe906e7d28b018010676af8",
-                // "e155217897df8cde740a688643b511fd8e477094efe906e7d28b018010676af8",
-                // "e155217897df8cde740a688643b511fd8e477094efe906e7d28b018010676af8",
             ];
             foreach (var dt in deviceTokens) {
                 attempted++;
@@ -49,11 +44,11 @@ namespace PushSharp.Tests
                             "content-available": 1,
                             "sound": "default",
                             "alert": {
-                              "title": "tyrtyrt",
+                              "title": "Test title",
                               "loc-key": "Notification.TaskMessageAdded.Body",
                               "loc-args": [
-                                "Natalia Romashevskaya",
-                                "@Administrator rtyrtyrtyrtyrty"
+                                "First Last",
+                                "@Administrator message"
                               ]
                             }
                           },
@@ -61,11 +56,11 @@ namespace PushSharp.Tests
                             "Type": "TaskMessageAdded",
                             "FeedId": 5813066,
                             "TaskId": 3900,
-                            "TaskName": "tyrtyrt",
+                            "TaskName": "Task Name",
                             "MessageId": 5855812,
-                            "MessageText": "@Administrator rtyrtyrtyrtyrty",
+                            "MessageText": "@Administrator message",
                             "PostedByUserId": 112,
-                            "PostedByUserName": "Natalia Romashevskaya"
+                            "PostedByUserName": "First Last"
                           }
                         }
                         """)

--- a/PushSharp.Tests/PushSharp.Tests.csproj
+++ b/PushSharp.Tests/PushSharp.Tests.csproj
@@ -9,9 +9,10 @@
     <OutputType>Library</OutputType>
     <RootNamespace>PushSharp.Tests</RootNamespace>
     <AssemblyName>PushSharp.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <LangVersion>14</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -83,6 +84,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="settings.json" />
   </ItemGroup>

--- a/PushSharp.Tests/PushSharp.Tests.csproj
+++ b/PushSharp.Tests/PushSharp.Tests.csproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>PushSharp.Tests</RootNamespace>
     <AssemblyName>PushSharp.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <LangVersion>14</LangVersion>

--- a/PushSharp.Tests/app.config
+++ b/PushSharp.Tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/PushSharp.Web/PushSharp.Web.csproj
+++ b/PushSharp.Web/PushSharp.Web.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PushSharp.Web</RootNamespace>
     <AssemblyName>PushSharp.Web</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/PushSharp.Web/PushSharp.Web.csproj
+++ b/PushSharp.Web/PushSharp.Web.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PushSharp.Web</RootNamespace>
     <AssemblyName>PushSharp.Web</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/PushSharp.Windows/PushSharp.Windows.csproj
+++ b/PushSharp.Windows/PushSharp.Windows.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>PushSharp.Windows</RootNamespace>
     <AssemblyName>PushSharp.Windows</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\PushSharp-Signing.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/PushSharp.Windows/PushSharp.Windows.csproj
+++ b/PushSharp.Windows/PushSharp.Windows.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>PushSharp.Windows</RootNamespace>
     <AssemblyName>PushSharp.Windows</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\PushSharp-Signing.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/PushSharp.nuspec
+++ b/PushSharp.nuspec
@@ -19,20 +19,20 @@
         <language>en-US</language>
         <tags>APN, APNS, GCM, XMPP, ADM, GCMXMPP, C2DM, PAP, BIS, BEM, Blackberry, iOS, Android, iPad, iPhone, PushSharp, MDM, UWP, WNS, Windows Notification, Amazon, Amazon Device, Push, Push Notifications, Google Cloud, Cloud Messaging, Google Cloud Messaging, OSX, Mac, WindowsPhone, PassKit</tags>
         <dependencies>
-            <dependency id="Newtonsoft.Json" version="7.0.1" />
+            <dependency id="Newtonsoft.Json" version="13.0.4" />
         </dependencies>
     </metadata>
     <files>
-        <file src="PushSharp.Core\bin\Release\PushSharp.Core.dll" target="lib\net45\PushSharp.Core.dll" />
+        <file src="PushSharp.Core\bin\Release\PushSharp.Core.dll" target="lib\net472\PushSharp.Core.dll" />
 
-        <file src="PushSharp.Amazon\bin\Release\PushSharp.Amazon.dll" target="lib\net45\PushSharp.Amazon.dll" />
-        <file src="PushSharp.Apple\bin\Release\PushSharp.Apple.dll" target="lib\net45\PushSharp.Apple.dll" />
+        <file src="PushSharp.Amazon\bin\Release\PushSharp.Amazon.dll" target="lib\net472\PushSharp.Amazon.dll" />
+        <file src="PushSharp.Apple\bin\Release\PushSharp.Apple.dll" target="lib\net472\PushSharp.Apple.dll" />
         <!-- <file src="PushSharp.Apple\bin\Release\HttpTwo.dll" target="lib\net45\HttpTwo.dll" /> -->
         <!-- <file src="PushSharp.Apple\bin\Release\HttpTwo.HPack.dll" target="lib\net45\HttpTwo.HPack.dll" /> -->
-        <file src="PushSharp.Firefox\bin\Release\PushSharp.Firefox.dll" target="lib\net45\PushSharp.Firefox.dll" />
-        <file src="PushSharp.Windows\bin\Release\PushSharp.Windows.dll" target="lib\net45\PushSharp.Windows.dll" />
-        <file src="PushSharp.Google\bin\Release\PushSharp.Google.dll" target="lib\net45\PushSharp.Google.dll" />
-        <file src="PushSharp.Web\bin\Release\PushSharp.Web.dll" target="lib\net45\PushSharp.Web.dll" />
-        <file src="PushSharp.Blackberry\bin\Release\PushSharp.Blackberry.dll" target="lib\net45\PushSharp.Blackberry.dll" />
+        <file src="PushSharp.Firefox\bin\Release\PushSharp.Firefox.dll" target="lib\net472\PushSharp.Firefox.dll" />
+        <file src="PushSharp.Windows\bin\Release\PushSharp.Windows.dll" target="lib\net472\PushSharp.Windows.dll" />
+        <file src="PushSharp.Google\bin\Release\PushSharp.Google.dll" target="lib\net472\PushSharp.Google.dll" />
+        <file src="PushSharp.Web\bin\Release\PushSharp.Web.dll" target="lib\net472\PushSharp.Web.dll" />
+        <file src="PushSharp.Blackberry\bin\Release\PushSharp.Blackberry.dll" target="lib\net48\PushSharp.Blackberry.dll" />
     </files>
 </package>


### PR DESCRIPTION
Task [AB#58127](https://dev.azure.com/LogicSoft/6cb672e1-c82e-44f0-84bb-562a3d037d62/_workitems/edit/58127): Support new APNS protocol
Product Backlog Item [AB#58106](https://dev.azure.com/LogicSoft/6cb672e1-c82e-44f0-84bb-562a3d037d62/_workitems/edit/58106): [iOS] Push notifications
Task for Testing [AB#58129](https://dev.azure.com/LogicSoft/6cb672e1-c82e-44f0-84bb-562a3d037d62/_workitems/edit/58129): tbd - check ios push notifications

### Description

- Refactored code for cleanup and addressed missed changes.
- Implemented the new Apple Push Notification Service (APNs) API to replace the deprecated protocol.
