### PR TITLE
Comment out common name validation for APNS certificate

### DIFF
--- a/PushSharp.Apple/ApnsHttp2Configuration.cs
+++ b/PushSharp.Apple/ApnsHttp2Configuration.cs
@@ -80,8 +80,8 @@ namespace PushSharp.Apple
 
                 if (!issuerName.Contains ("Apple"))
                     throw new ApnsConnectionException ("Your Certificate does not appear to be issued by Apple!  Please check to ensure you have the correct certificate!");
-                if (!commonName.Contains ("Apple Push Services:"))
-                    throw new ApnsConnectionException ("Your Certificate is not in the new combined Sandbox/Production APNS certificate format, please create a new single certificate to use");
+                //if (!commonName.Contains ("Apple Push Services:"))
+                //    throw new ApnsConnectionException ("Your Certificate is not in the new combined Sandbox/Production APNS certificate format, please create a new single certificate to use");
 
             } else {
                 throw new ApnsConnectionException ("You must provide a Certificate to connect to APNS with!");


### PR DESCRIPTION
Currently we have certificate for sandbox env with subject ` Apple Sandbox Push Services...` , and it doesn't meet this validation. Just removed this check because it's not so important for us